### PR TITLE
Extend rake release:supermarket with multiple additional options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.4.
+## Version 0.4.0
 
 - Extend rake release:supermarket with multiple additional options
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.4.
+
+- Extend rake release:supermarket with multiple additional options
+
 ## Version 0.3.0
 
 - Enable `cookstyle` as linting option for `rake test:lint:cookbook[autocorrect]` with autocorrect options

--- a/README.md
+++ b/README.md
@@ -107,10 +107,19 @@ Upload to Artifactory with required settings like:
 Upload to Chef Server.
 It uses the current configured supermarket in your knife.rb or config.rb.
 
-### rake release:supermarket
+### rake release:supermarket[siteurl,user,authkeyfile,cookbookpath,cookbookname,configfile]
 
 Upload to Chef Supermarket.
 It uses the current configured supermarket in your knife.rb or config.rb.
+
+You are also allowed to use multiple additional settings:
+
+* `siteurl`: defines the url of a Chef Supermarket
+* `user`: the user to authenticate
+* `authkeyfile`: the keyfile to use (it must be a file present on your system)
+* `cookbookpath`: the path where to look up for cookbooks (default: `../`)
+* `cookbookname`: define different cookbookname instead of the current one
+* `configfile`: define a config.rb file instead of the settings above (this might look like `rake release:supermarket[,,,,,~/.chef/config.rb]`)
 
 ## Repin Tasks
 

--- a/lib/chef/raketasks/release.rb
+++ b/lib/chef/raketasks/release.rb
@@ -80,12 +80,7 @@ module ChefRake
             metadata.from_file File.join(current_dir, 'metadata.rb')
 
             args.with_defaults(
-              siteurl: nil,
-              user: nil,
-              authkeyfile: nil,
-              cookbookpath: parent_dir,
-              cookbookname: nil,
-              configfile: nil
+              cookbookpath: parent_dir
             )
 
             cmd = "knife supermarket share #{metadata.name}"

--- a/lib/chef/raketasks/release.rb
+++ b/lib/chef/raketasks/release.rb
@@ -70,7 +70,7 @@ module ChefRake
           end
 
           desc 'Upload to Chef Supermarket'
-          task :supermarket do
+          task :supermarket, [:siteurl, :user, :authkeyfile, :cookbookpath, :cookbookname, :configfile] do |_t, args|
             Rake::Task['clean:cookbook'].execute
 
             require 'berkshelf'
@@ -79,8 +79,25 @@ module ChefRake
             metadata = Chef::Cookbook::Metadata.new
             metadata.from_file File.join(current_dir, 'metadata.rb')
 
+            args.with_defaults(
+              siteurl: nil,
+              user: nil,
+              authkeyfile: nil,
+              cookbookpath: parent_dir,
+              cookbookname: nil,
+              configfile: nil
+            )
+
             cmd = "knife supermarket share #{metadata.name}"
-            cmd << " --cookbook-path #{parent_dir}"
+            if args.configfile.nil?
+              cmd << " --cookbook-path #{parent_dir}"
+              cmd << " --supermarket-site #{args.siteurl}" unless args.siteurl.nil?
+              cmd << " --user #{args.user}" unless args.user.nil?
+              cmd << " --key #{args.authkeyfile}" unless args.authkeyfile.nil?
+            elsif args.configfile
+              cmd << " --config #{args.configfile}" unless args.configfile.nil?
+            end
+
             sh cmd
 
             # require 'chef/mixin/shell_out'

--- a/lib/chef/raketasks/version.rb
+++ b/lib/chef/raketasks/version.rb
@@ -18,6 +18,6 @@
 
 module ChefRake
   module Task
-    VERSION = '0.3.0'.freeze
+    VERSION = '0.4.0'.freeze
   end
 end


### PR DESCRIPTION
## Description

This change allows to use internal supermarkets or even Artifactory for cookbook uploads.

## Issues Resolved

none

## Check List

- [X] A summary of changes made is included in the CHANGELOG
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
