### PR TITLE
Add gem vendoring ability for cookbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.5.0
+
+- Add gem:vendor as new raketask to vendor gems for cookbooks and others
+
 ## Version 0.4.0
 
 - Extend rake release:supermarket with multiple additional options

--- a/README.md
+++ b/README.md
@@ -78,10 +78,12 @@ Installs vcenter sdk for kitchen.
 
 ### rake gem:vendor[gemname, version, source, installdir]
 
-Installs vcenter sdk for kitchen.
+Vendors rubygems to a specific directory inside the cookbook
 
+* `gemname`: the name of the gem to be used
 * `version`: define a specific version of the gem
 * `source`: define a different source than rubygems.org
+* `installdir`: define the desired targetdir where the vendoring should happen
 
 ## Packaging Tasks
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Installs vcenter sdk for kitchen.
 * `version`: define a specific version of the gem
 * `source`: define a different source than rubygems.org
 
+### rake gem:vendor[gemname, version, source, installdir]
+
+Installs vcenter sdk for kitchen.
+
+* `version`: define a specific version of the gem
+* `source`: define a different source than rubygems.org
+
 ## Packaging Tasks
 
 ### rake package:cookbook

--- a/lib/chef/raketasks/gem.rb
+++ b/lib/chef/raketasks/gem.rb
@@ -73,8 +73,8 @@ module ChefRake
           desc 'Vendors gems into cookbook'
           task :vendor, [:gemname, :version, :source, :installdir] do |_t, args|
             args.with_defaults(
-              version: ::Gem::Requirement.default.to_s, # will use latest when not set
-              source: 'https://rubygems.org',
+              version: '>= 0', # so use latest when not set
+              source: nil,
               installdir: 'files/default/vendor'
             )
 

--- a/lib/chef/raketasks/gem.rb
+++ b/lib/chef/raketasks/gem.rb
@@ -30,7 +30,7 @@ module ChefRake
             cmd << "-v \"#{version}\" " unless version.nil?
             cmd << "-s #{source} " unless source.nil?
             cmd << "--install-dir #{installdir} " unless installdir.nil? # used mostly for vendoring
-            cmd << "--no-user-install " unless installdir.nil? # used for vendoring
+            cmd << '--no-user-install ' unless installdir.nil? # used for vendoring
             cmd << '--no-document'
 
             sh cmd

--- a/lib/chef/raketasks/gem.rb
+++ b/lib/chef/raketasks/gem.rb
@@ -24,18 +24,20 @@ module ChefRake
         super
 
         namespace :gem do
+          def install_gem(name, version, source, installdir)
+            cmd = 'chef gem install '
+            cmd << "#{name} "
+            cmd << "-v \"#{version}\" " unless version.nil?
+            cmd << "-s #{source} " unless source.nil?
+            cmd << "--install-dir #{installdir} " unless installdir.nil? # used mostly for vendoring
+            cmd << "--no-user-install " unless installdir.nil? # used for vendoring
+            cmd << '--no-document'
+
+            sh cmd
+          end
+
           desc 'gem:install'
           namespace :install do
-            def install_gem(name, version, source)
-              cmd = 'chef gem install '
-              cmd << "#{name} "
-              cmd << "-v #{version} " unless version.nil?
-              cmd << "-s #{source} " unless source.nil?
-              cmd << '--no-document'
-
-              sh cmd
-            end
-
             # NAMESPACE: gem:install:static
             desc 'Installs necessary static gems for kitchen'
             task static: %i[
@@ -66,6 +68,18 @@ module ChefRake
               end
             end # namespace vcenter
           end # namespace install
+
+          # NAMESPACE: gem:vendor
+          desc 'Vendors gems into cookbook'
+          task :vendor, [:gemname, :version, :source, :installdir] do |_t, args|
+            args.with_defaults(
+              version: ::Gem::Requirement.default.to_s, # will use latest when not set
+              source: 'https://rubygems.org',
+              installdir: 'files/default/vendor'
+            )
+
+            install_gem(args.gemname, args.version, args.source, args.installdir)
+          end
         end # namespace gem
       end # def initialize
     end # class Gem

--- a/lib/chef/raketasks/version.rb
+++ b/lib/chef/raketasks/version.rb
@@ -18,6 +18,6 @@
 
 module ChefRake
   module Task
-    VERSION = '0.4.0'.freeze
+    VERSION = '0.5.0'.freeze
   end
 end


### PR DESCRIPTION
## Description

This change brings in the ability to vendor gems into the local file system. Mainly this is used to bundle gems like vault into a cookbook instead of installing it on every single system where the gem is needed for using some library.

The default dir is, outgoing from the current dir, this target directory: `files/default/vendor`

## Issues Resolved

None

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
